### PR TITLE
Update package.json to bring this up-to-date

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Proxy between websocket and tcp servers",
   "bin" : { "ws-tcp-bridge" : "./ws-tcp-bridge" },
   "dependencies": {
-    "optimist": "~0.3.5",
-    "ws": "~0.4.23"
+    "optimist": "~0.6.1",
+    "ws": "~1.1.0"
   },
   "devDependencies": {},
   "scripts": {
@@ -22,5 +22,5 @@
     "tcp"
   ],
   "author": "andrewchamberss@gmail.com",
-  "license": "BSD"
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
optimits and ws updated to currently working versions
License named from "BSD" to "BSD-3-Clause" as npm complained: "npm WARN ws-tcp-bridge@1.0.0 license should be a valid SPDX license expression"
BSD-2-Clause or 0BSD is another possibility

With the small change, "npm install" runs without warnings. The bridge works fine (of course).
